### PR TITLE
change Dockerfile instruction to uppercase

### DIFF
--- a/src/frontend_react/Dockerfile.example
+++ b/src/frontend_react/Dockerfile.example
@@ -6,7 +6,7 @@
 # It also proxies /api requests to api:5000
 
 # Build step #1: build the React front end
-FROM node:18 as build-step
+FROM node:18 AS build-step
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
 COPY package.json package-lock.json ./


### PR DESCRIPTION
Accordingt to [Sonarqube](https://rules.sonarsource.com/docker/RSPEC-6476) Dockerfile instructions should be uppercase.